### PR TITLE
Add missing setuptools dependency. This should fix JupyterLite issue.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,12 @@ readme = "README.md"
 include = ["vendor/compare_view/browser_compare_view.js"]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.13"
+python = ">=3.8,<3.13"
 ipython = ">=6.0.0"
 ipykernel = ">=5.0.0"
 Pillow = ">=7.1.2"
 Jinja2 = ">=2.11.3"
+setuptools = ">=60.0.0"
 
 [tool.poetry.dev-dependencies]
 black = { extras = ["jupyter"], version = ">=22.3.0" }


### PR DESCRIPTION
See https://github.com/jupyterlite/jupyterlite/issues/818

Note that I bumped the minimum Python version to 3.8 because SciPy would not install without that change.